### PR TITLE
Handle URL Encoding for Requests

### DIFF
--- a/lib/proxy/oauth/signatures/oauth1a.js
+++ b/lib/proxy/oauth/signatures/oauth1a.js
@@ -95,13 +95,13 @@ exports.constructStringsToSign = function(req) {
 
   if (req.parsed_url.protocol) {
   	return [
- 	   sprintf("%s&%s&%s", method, encoding.encodeData(sprintf("%s//%s%s", req.parsed_url.protocol, req.headers.host, req.parsed_url.pathname)), parameters)
+ 	   sprintf("%s&%s&%s", method, encoding.encodeData(sprintf("%s//%s%s", req.parsed_url.protocol, req.headers.host, encoding.decodeData(req.parsed_url.pathname))), parameters)
   	];
   }
 
   // Optimistically assume we will only need to sign an https string.
   var signable_strings =  [
-    sprintf("%s&%s&%s", method, encoding.encodeData(sprintf("https://%s%s", req.headers.host, req.parsed_url.pathname)), parameters)
+    sprintf("%s&%s&%s", method, encoding.encodeData(sprintf("https://%s%s", req.headers.host, encoding.decodeData(req.parsed_url.pathname))), parameters)
   ];
 
   // If x-forwarded-proto is present and starts with https, we know that the original request was for an https url and
@@ -111,7 +111,7 @@ exports.constructStringsToSign = function(req) {
   }
 
   // If we don't know whether the inbound request was https or http, return both.
-  signable_strings.push(sprintf("%s&%s&%s", method, encoding.encodeData(sprintf("http://%s%s", req.headers.host, req.parsed_url.pathname)), parameters));
+  signable_strings.push(sprintf("%s&%s&%s", method, encoding.encodeData(sprintf("http://%s%s", req.headers.host, encoding.decodeData(req.parsed_url.pathname))), parameters));
 
   return signable_strings;
 };


### PR DESCRIPTION
Update the oauth validator to ensure that incoming URL paths are decoded
prior to being encoded. This is necessary because without decoding
first, you can potentially end up with double-encoded paths, which will
create signature mis-matches (i.e. /users/{user}/dothis will
double-encode the curly-braces due to the incoming request already being
URL encoded).
