### PR TITLE
Fix Signature Encoding Scheme for Parameters

### DIFF
--- a/lib/proxy/oauth/signatures/oauth1a.js
+++ b/lib/proxy/oauth/signatures/oauth1a.js
@@ -21,8 +21,8 @@ function normaliseRequestParams(argument_pairs) {
 
   // First encode them http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2 .1
   for (var i=0; i<argument_pairs.length; i++) {
-    argument_pairs[i][0] = encoding.encodeData(argument_pairs[i][0]);
-    argument_pairs[i][1] = encoding.encodeData(argument_pairs[i][1]);
+    argument_pairs[i][0] = encoding.encodeData(encoding.decodeData(argument_pairs[i][0]));
+    argument_pairs[i][1] = encoding.encodeData(encoding.decodeData(argument_pairs[i][1]));
   }
 
   // Then sort them http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2 .2
@@ -40,9 +40,9 @@ function normaliseRequestParams(argument_pairs) {
       continue;
     }
     **/
-    args += sprintf("%s=%s", argument_pairs[i][0], argument_pairs[i][1]);
+    args += sprintf("%s%%3D%s", argument_pairs[i][0], argument_pairs[i][1]);
     if (i < argument_pairs.length-1) {
-      args+= "&";
+      args+= "%26";
     }
   }
 
@@ -90,7 +90,7 @@ exports.collectParams = function(req, collection) {
 // https signature, but we take the pessimistic approach that upstream proxies can not be trusted to set the headers
 // we need.  We will return an http-based string unless we see an x-forwarded-proto header that starts with https.
 exports.constructStringsToSign = function(req) {
-  var parameters = encoding.encodeData(normaliseRequestParams(req.argument_pairs));
+  var parameters = normaliseRequestParams(req.argument_pairs);
   var method = req.method.toUpperCase();
 
   if (req.parsed_url.protocol) {


### PR DESCRIPTION
Since the OAuth Signature base is calculated and follows the RFC
requirement to encode parameters prior to doing anything else (sorting,
etc), it is necessary to pass a decoded version of all parameters to the
function, and then encode once. Removed extraneous flip-flopping of
encodings, which cause an issue if parameters passed have special
characters (i.e. spaces, percent symbols, etc).
