### PR TITLE
Add CORS Support/Error Msg for Unauthorized

### DIFF
--- a/lib/proxy/messages/unauthorized.js
+++ b/lib/proxy/messages/unauthorized.js
@@ -9,8 +9,8 @@ var module_tag = {
 module.exports = function(logger, req, res, message) {
   logger.info(module_tag, "Rejecting %s %s%s, error %s", req.method, req.headers.host, req.url, message);
   process.nextTick(function() {
-    res.writeHead(401, message);
-    res.end();
+    res.writeHead(401, message, { 'Access-Control-Allow-Origin': '*' });
+    res.end(message);
   });
 
   // Return false from this method so it can signal to a calling function that the request failed.


### PR DESCRIPTION
Update the unauthorized functionality to allow all origin and pass back
messages to the caller. This avoids an issue where integrations with
downstream products that exist within different origins result in a
failure due to the missing Access-Control-Allow-Origin header.
