### PR TITLE
Add support for HMAC_SHA256

### DIFF
--- a/lib/proxy/mutators/oauth_param_generator.js
+++ b/lib/proxy/mutators/oauth_param_generator.js
@@ -11,7 +11,7 @@ var module_tag = {
   module: require('../../logger.js').getModulePath(__filename)
 };
 
-var SIGNATURE_METHOD = oauth_constants.OAUTH_1A_SIGNATURE_METHOD;
+var SIGNATURE_METHOD = "HMAC-SHA1";
 
 /**
  * The oauth_param_generator serves an inverse purpose to the reverse proxy's oauth_param_collector

--- a/lib/proxy/oauth/constants.js
+++ b/lib/proxy/oauth/constants.js
@@ -5,7 +5,12 @@ var OAUTH_SIGNATURE_METHOD = exports.OAUTH_SIGNATURE_METHOD = 'oauth_signature_m
 var OAUTH_TIMESTAMP = exports.OAUTH_TIMESTAMP = 'oauth_timestamp';
 var OAUTH_VERSION = exports.OAUTH_VERSION = 'oauth_version';
 
-var OAUTH_1A_SIGNATURE_METHOD = exports.OAUTH_1A_SIGNATURE_METHOD = 'HMAC-SHA1';
+// Store the signature methods we allow as a map from method type in the OAuth spec to node's
+// name for that type.
+var OAUTH_1A_ALLOWED_SIGNATURE_METHODS = exports.OAUTH_1A_ALLOWED_SIGNATURE_METHODS = {
+  'HMAC-SHA1' : 'sha1',
+  'HMAC-SHA256' : 'sha256'
+};
 
 var CONSUMER_KEY_HEADER = exports.CONSUMER_KEY_HEADER = 'x-oauth-reverse-proxy-consumer-key';
 

--- a/lib/proxy/validators/oauth_param_sanity_validator.js
+++ b/lib/proxy/validators/oauth_param_sanity_validator.js
@@ -21,9 +21,10 @@ module.exports = function(proxy) {
       return bad_request(proxy.logger, req, res, 'Authorization type is not OAuth');
     }
 
-    // Only HMAC-SHA1 is supported, per the spec.
-    if (req.oauth_params[oauth_constants.OAUTH_SIGNATURE_METHOD] !== oauth_constants.OAUTH_1A_SIGNATURE_METHOD) {
-      return bad_request(proxy.logger, req, res, 'Only OAuth 1.0a with HMAC-SHA1 is supported');
+    // Only HMAC-SHA1 or HMAC-SHA256 are supported.  HMAC-SHA1 is the only method specifically listed in
+    // the spec, but there's no harm in adding support for 256.
+    if (oauth_constants.OAUTH_1A_ALLOWED_SIGNATURE_METHODS[req.oauth_params[oauth_constants.OAUTH_SIGNATURE_METHOD]] === undefined) {
+      return bad_request(proxy.logger, req, res, 'Only OAuth 1.0a with HMAC-SHA1 or HMAC-SHA256 is supported');
     }
 
     proxy.logger.trace(require('util').inspect(req.oauth_params));

--- a/lib/proxy/validators/oauth_signature_validator.js
+++ b/lib/proxy/validators/oauth_signature_validator.js
@@ -9,8 +9,10 @@ var crypto = require('crypto');
 
 var oauth1a = require('../oauth/signatures/oauth1a.js');
 
+var OAUTH_1A_ALLOWED_SIGNATURE_METHODS = require('../oauth/constants.js').OAUTH_1A_ALLOWED_SIGNATURE_METHODS;
 var OAUTH_CONSUMER_KEY = require('../oauth/constants.js').OAUTH_CONSUMER_KEY;
 var OAUTH_SIGNATURE = require('../oauth/constants.js').OAUTH_SIGNATURE;
+var OAUTH_SIGNATURE_METHOD = require('../oauth/constants.js').OAUTH_SIGNATURE_METHOD;
 
 var CONSUMER_KEY_HEADER = require('../oauth/constants.js').CONSUMER_KEY_HEADER;
 
@@ -51,7 +53,7 @@ module.exports = function(proxy) {
         var signature_base = signature_bases.shift();
         proxy.logger.debug(module_tag, "Got signature_base\n%s", signature_base);
 
-        var hash = crypto.createHmac("sha1", consumer_secret).update(signature_base).digest("base64");
+        var hash = crypto.createHmac(OAUTH_1A_ALLOWED_SIGNATURE_METHODS[req.oauth_params[OAUTH_SIGNATURE_METHOD]], consumer_secret).update(signature_base).digest("base64");
 
         proxy.logger.trace(module_tag, "Hash\t%s", hash);
         proxy.logger.trace(module_tag, "Sig\t%s", req.oauth_params[OAUTH_SIGNATURE]);

--- a/test/clients/bash/client.sh
+++ b/test/clients/bash/client.sh
@@ -5,9 +5,9 @@ CONSUMER_SECRET=`cat ../../keys/8008/8080/$CONSUMER_KEY`\&
 TIME=$(($(date +'%s * 1000 + %-N / 1000000')))
 NONCE=$(date +%s | shasum | base64 | head -c 32 ; echo)
 
-TO_SIGN="GET&http%3A%2F%2Flocalhost%3A8008%2Fjob%2F12345&oauth_consumer_key%3D$CONSUMER_KEY%26oauth_nonce%3D$NONCE%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D$TIME%26oauth_version%3D1.0"
+TO_SIGN="GET&http%3A%2F%2Flocalhost%3A8008%2Fjob%2F12345&oauth_consumer_key%3D$CONSUMER_KEY%26oauth_nonce%3D$NONCE%26oauth_signature_method%3DHMAC-SHA256%26oauth_timestamp%3D$TIME%26oauth_version%3D1.0"
 
-SIGNATURE=`echo -n $TO_SIGN | openssl sha1 -hmac "$CONSUMER_SECRET" -binary | base64`
+SIGNATURE=`echo -n $TO_SIGN | openssl dgst -sha256 -hmac "$CONSUMER_SECRET" -binary | base64`
 
 #curl -v -G --data-urlencode "oauth_consumer_key=$CONSUMER_KEY" --data-urlencode "oauth_nonce=$NONCE" --data-urlencode "oauth_signature_method=HMAC-SHA1" --data-urlencode "oauth_signature=$SIGNATURE" --data-urlencode "oauth_version=1.0" --data-urlencode "oauth_timestamp=$TIME" http://localhost:8000/job
-curl --silent -G --data-urlencode "oauth_consumer_key=$CONSUMER_KEY" --data-urlencode "oauth_nonce=$NONCE" --data-urlencode "oauth_signature_method=HMAC-SHA1" --data-urlencode "oauth_signature=$SIGNATURE" --data-urlencode "oauth_version=1.0" --data-urlencode "oauth_timestamp=$TIME" http://localhost:8008/job/12345
+curl --silent -G --data-urlencode "oauth_consumer_key=$CONSUMER_KEY" --data-urlencode "oauth_nonce=$NONCE" --data-urlencode "oauth_signature_method=HMAC-SHA256" --data-urlencode "oauth_signature=$SIGNATURE" --data-urlencode "oauth_version=1.0" --data-urlencode "oauth_timestamp=$TIME" http://localhost:8008/job/12345

--- a/test/clients/perl/client.pl
+++ b/test/clients/perl/client.pl
@@ -20,7 +20,7 @@ my $oauth_request = Net::OAuth->request('consumer')->new(
   consumer_secret => $consumer_secret,
   request_url => url(),
   request_method => 'GET',
-  signature_method => 'HMAC-SHA1',
+  signature_method => 'HMAC-SHA256',
   timestamp => time,
   nonce => nonce(),
 );

--- a/test/message_integrity_compression_test.js
+++ b/test/message_integrity_compression_test.js
@@ -24,7 +24,7 @@ require('./bootstrap_test.js');
     ['GET', 'POST', 'PUT', 'DELETE'].forEach(function(verb) {
 
       // Validate that a response containing gzipped content is handled properly.
-      it ("should handle a gzipped response to a " + verb, function(done) {
+      it ("should handle a " + mode + " gzipped response to a " + verb, function(done) {
         sendFn(verb, 'http://localhost:8008/compressed_content', {headers:{'accept-encoding':'gzip'}}, 200,
         function(err, res, body) {
           res.headers['content-encoding'].should.equal('gzip');
@@ -34,7 +34,7 @@ require('./bootstrap_test.js');
       });
 
       // Validate that a response containing deflated content is handled properly.
-      it ("should handle a gzipped response to a " + verb, function(done) {
+      it ("should handle a " + mode + " gzipped response to a " + verb, function(done) {
         sendFn(verb, 'http://localhost:8008/compressed_content', {headers:{'accept-encoding':'deflate'}}, 200,
         function(err, res, body) {
           res.headers['content-encoding'].should.equal('deflate');

--- a/test/oauth_validations_test.js
+++ b/test/oauth_validations_test.js
@@ -16,7 +16,7 @@ describe('OAuth validations', function() {
 
     // Validate that an invalid signature method results in a 400 error.
     it ("should reject " + verb + " requests with invalid signature methods", function(done) {
-      request_sender.oauth_headers[2][1] = 'HMAC-SHA256';
+      request_sender.oauth_headers[2][1] = 'HMAC-BLOWFISH';
       request_sender.sendSimpleAuthenticatedRequest(verb, 400, done);
     });
 


### PR DESCRIPTION
This patch allows for OAuth messages to be reverse proxied if they have a valid SHA256 signature.
